### PR TITLE
Fixed a bug that happened on a connection error when fetching data from a remote server.

### DIFF
--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -23,6 +23,7 @@ import 'package:horstler/screens/menu_screen.dart';
 import 'package:horstler/screens/schedule_screen.dart';
 import 'package:horstler/screens/splash_screen.dart';
 import 'package:horstler/screens/welcome_screen.dart';
+import 'package:retry/retry.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 class DrawerItem {
@@ -86,14 +87,14 @@ class HomeScreenState extends State<HomeScreen> {
   @override
   Widget build(BuildContext context) {
     return FutureBuilder(
-      future: _checkForLogin(),
+      future: retry(() => _checkForLogin().timeout(Duration(seconds: 5))),
       builder: (BuildContext context, AsyncSnapshot snapshot) {
         if (snapshot.hasError) {
           print(snapshot.error);
         }
         if (!snapshot.hasData) {
           return SplashScreen(
-            seconds: 30,
+            seconds: 51,
             navigateAfterSeconds: '/loginScreen',
             title: Text('horstler'),
             image: Image(

--- a/lib/screens/menu_screen.dart
+++ b/lib/screens/menu_screen.dart
@@ -20,6 +20,7 @@ import 'package:flutter/material.dart';
 import 'package:horstl_wrapper/horstl_wrapper.dart';
 import 'package:horstler/widgets/dish_widget.dart';
 import 'package:horstler/screens/splash_screen.dart';
+import 'package:retry/retry.dart';
 
 class MenuScreen extends StatefulWidget {
   final String fdNumber;
@@ -45,7 +46,9 @@ class _MenuScreenState extends State {
     var menuWeek = <Menu>[];
     var day = currentDay;
     for (int i = 0; i < 6; i++) {
-      var menu = await HorstlScrapper(fdNumber, passWord).getMenu(day);
+      var menu = await HorstlScrapper(fdNumber, passWord)
+          .getMenu(day)
+          .timeout(Duration(seconds: 5));
       menuWeek.add(menu);
       day = day.add(Duration(days: 1));
     }
@@ -61,7 +64,8 @@ class _MenuScreenState extends State {
       _requestedDay = _requestedDay.add(Duration(days: 1));
     _requestedMonday = _getCurrentMonday(_requestedDay);
 
-    _menuFuture = _getMenuFromFuture(_fdNumber, _passWord, _requestedMonday);
+    _menuFuture =
+        retry(() => _getMenuFromFuture(_fdNumber, _passWord, _requestedMonday));
   }
 
   @override
@@ -77,7 +81,7 @@ class _MenuScreenState extends State {
     };
 
     var splashScreen = SplashScreen(
-      seconds: 20,
+      seconds: 51,
       navigateAfterSeconds: '/loginScreen',
       title: Text('horstler'),
       image: Image(

--- a/lib/screens/schedule_screen.dart
+++ b/lib/screens/schedule_screen.dart
@@ -20,6 +20,7 @@ import 'package:flutter/material.dart';
 import 'package:horstl_wrapper/horstl_wrapper.dart';
 import 'package:horstler/widgets/course_widget.dart';
 import 'package:horstler/screens/splash_screen.dart';
+import 'package:retry/retry.dart';
 
 class ScheduleScreen extends StatefulWidget {
   final String fdNumber;
@@ -43,8 +44,9 @@ class _ScheduleScreenState extends State {
 
   Future<Schedule> _getDataFromFuture(
       String fdNumber, String passWord, int calendarWeek, int year) async {
-    return HorstlScrapper(fdNumber, passWord)
-        .getScheduleForWeek(calendarWeek, year);
+    return retry(() => HorstlScrapper(fdNumber, passWord)
+        .getScheduleForWeek(calendarWeek, year)
+        .timeout(Duration(seconds: 5)));
   }
 
   @override
@@ -79,7 +81,7 @@ class _ScheduleScreenState extends State {
     ][currentDay.weekday - 1];
 
     var splashScreen = SplashScreen(
-      seconds: 20,
+      seconds: 51,
       navigateAfterSeconds: '/loginScreen',
       title: Text('horstler'),
       image: Image(

--- a/lib/screens/welcome_screen.dart
+++ b/lib/screens/welcome_screen.dart
@@ -8,6 +8,7 @@ import 'package:horstler/widgets/course_widget.dart';
 import 'package:horstler/widgets/dish_showcase.dart';
 import 'package:intl/intl.dart';
 import 'package:intl/date_symbol_data_local.dart';
+import 'package:retry/retry.dart';
 
 class WelcomeScreen extends StatefulWidget {
   final String fdNumber;
@@ -54,11 +55,13 @@ class _WelcomeScreenState extends State<WelcomeScreen> {
     initializeDateFormatting('de_DE');
     _scrapper = HorstlScrapper(_fdNumber, _passWord);
     _currentTime = DateTime.now();
-    _dataFuture = _getDataFromFuture();
+    _dataFuture =
+        retry(() => _getDataFromFuture().timeout(Duration(seconds: 5)));
     _dataRefresher = Timer.periodic(Duration(minutes: 5), (Timer t) {
       setState(() {
         _currentTime = DateTime.now();
-        _dataFuture = _getDataFromFuture();
+        _dataFuture =
+            retry(() => _getDataFromFuture().timeout(Duration(seconds: 5)));
       });
     });
     _timeRefresher = Timer.periodic(Duration(seconds: 30), (Timer t) {
@@ -78,7 +81,7 @@ class _WelcomeScreenState extends State<WelcomeScreen> {
   @override
   Widget build(BuildContext context) {
     var splashScreen = SplashScreen(
-      seconds: 20,
+      seconds: 51,
       navigateAfterSeconds: '/loginScreen',
       title: Text('horstler'),
       image: Image(

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -291,6 +291,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "3.0.13"
+  retry:
+    dependency: "direct main"
+    description:
+      name: retry
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "3.0.1"
   shared_preferences:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,7 +11,7 @@ description: Student helper app for the Fulda University of Applied Sciences.
 # In iOS, build-name is used as CFBundleShortVersionString while build-number used as CFBundleVersion.
 # Read more about iOS versioning at
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
-version: 0.1.1+3
+version: 0.1.1+4
 
 environment:
   sdk: ">=2.1.0 <3.0.0"
@@ -28,6 +28,7 @@ dependencies:
   flutter_advanced_networkimage: ^0.7.0
   # webview_flutter: ^0.3.18+1
   # flutter_inappwebview: ^2.1.0+1
+  retry: ^3.0.0
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.


### PR DESCRIPTION
This bug caused the app to return to the login screen after showing a long loading screen after an unsuccessful connection (e.g. when switching from mobile to WIFI while the app is loading some data from the network).

The app now uses the [retry](https://pub.dev/packages/retry) package to automatically retry connecting a few times on error which should fix this behavior.